### PR TITLE
Trocar Circuitos Integrados por Circuitos Lógicos

### DIFF
--- a/content/tutorial/comprando_ci.md
+++ b/content/tutorial/comprando_ci.md
@@ -1,5 +1,5 @@
 ---
-title: "Manual de compras de Circuitos Integrados"
+title: "Manual de compras de Circuitos Lógicos"
 date: 2020-01-30T00:12:00-03:00
 draft: false
 ---
@@ -13,6 +13,7 @@ Para essa receita você vai precisar de:
 1. Pergunte ao professor, logo no começo das aulas, sobre os materiais necessários. Se é que existe alguém que sabe quais serão, é ele.
 2. Prepare uma lista com os materiais necessários e vá até a Rua República do Líbano, no Centro. Um jeito fácil de chegar lá é pegando a Linha 3 do VLT Carioca e saltando na estação *Saara*. Chegando lá, você deve ir nas diversas lojas, vendo onde cada componente está mais barato e anotando na lista. Combine com os colegas para comprarem juntos: Em maior quantidade é possível barganhar por preços melhores.
 3. Eventualmente, você pode precisar de componentes mais complexos, como um *decodificador BCD*, por exemplo. Caso algo assim aconteça, você deve telefonar pras lojas para saber quais tem o componente em estoque, assim como o seu preço. Quando achar em um lugar legal, você pede pro atendente separar e vai lá buscar! Assim você evita perder a viagem.
+4. Uma boa dica é sempre montar a lista de material **depois** de terminar o projeto a ser montado na *protoboard*, assim você evita comprar peças a mais e garante que terá tudo necessário para montar sem contratempos. 
 
 ## Observações
 1. A maioria das portas lógicas custa em torno de R$1, enquanto CI's mais complexos podem custar na faixa de $5-$10. **Não mais do que isso!**


### PR DESCRIPTION
Circuito Integrado é o componente, mas também é o nome de uma disciplina do DEL, melhor deixar CL para as pessoas saberem do que se trata.